### PR TITLE
Add software control of pump laser wavelength

### DIFF
--- a/LaserControls.py
+++ b/LaserControls.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 28 2026
+
+@author: Wesley Mills and ChatGPT
+"""
+
+import serial
+import time
+
+DEFAULT_PORT = "COM6"
+DEFAULT_BAUD = 19200
+
+
+class ChameleonLaser:
+
+    def __init__(self, name, port: str = DEFAULT_PORT, baud: int = DEFAULT_BAUD, timeout: float = 2):
+        self.name = name
+        self.port = port
+        self.baud = baud
+        self.timeout = timeout
+        self.device = None
+        self._connected = False
+
+    # ------ Connection Handling ------
+    def connect(self):
+        try:
+            self.device = serial.Serial(self.port, self.baud, timeout=self.timeout)
+            # Flush stale welcome/status bytes left over from opening the port,
+            # otherwise the first ack read in set_wavelength() consumes garbage
+            # instead of the laser's real response.
+            self.device.reset_input_buffer()
+            self.device.reset_output_buffer()
+            time.sleep(0.5)
+        except Exception as e:
+            print(f"Failed to connect to {self.name}: {e}")
+            return
+        self._connected = True
+        print(f"{self.name} connected on {self.port}.")
+        # Prime the connection; without an initial read the laser can ignore
+        # the very first set_wavelength() command.
+        self.get_wavelength()
+        time.sleep(0.2)
+
+    def disconnect(self):
+        if self.device is not None:
+            self.device.close()
+            self._connected = False
+            print(f"{self.name} disconnected.")
+
+    # ------ Status ------
+    def get_wavelength(self) -> float:
+        self._ensure_connected()
+        self.device.write(b"?VW\r")
+        response = self.device.readline().decode("ascii", errors="replace").strip()
+        try:
+            return float(response.split()[-1])
+        except (ValueError, IndexError):
+            print(f"{self.name}: unexpected wavelength response: {response!r}")
+            return None
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    # ------ Wavelength Control ------
+    def set_wavelength(self, wavelength_nm: float, tolerance_nm: float = 0.5,
+                        poll_interval_s: float = 1.0, max_wait_s: float = 20.0) -> bool:
+        self._ensure_connected()
+        print(f"Setting {self.name} wavelength to {wavelength_nm} nm...")
+        ack = self._send_wavelength(wavelength_nm)
+        print(f"{self.name} set response: {ack!r}")
+
+        confirmed = None
+        n_polls = int(max_wait_s / poll_interval_s)
+        for poll_n in range(n_polls):
+            time.sleep(poll_interval_s)
+            confirmed = self.get_wavelength()
+            if confirmed is not None and abs(confirmed - wavelength_nm) <= tolerance_nm:
+                print(f"{self.name} wavelength confirmed: {confirmed:.1f} nm")
+                return True
+            if confirmed is not None:
+                print(f"Waiting for {self.name}... current: {confirmed:.1f} nm (target {wavelength_nm:.1f} nm)")
+            # If 5 s have passed with no movement, the first command may have
+            # been silently dropped; resend it once.
+            if poll_n == 4 and confirmed is not None and abs(confirmed - wavelength_nm) > 1.0:
+                print(f"{self.name}: no movement detected, resending wavelength command...")
+                ack = self._send_wavelength(wavelength_nm)
+                print(f"{self.name} set response (retry): {ack!r}")
+        print(f"WARNING: {self.name} did not reach {wavelength_nm:.1f} nm within {max_wait_s}s "
+              f"(last reading: {confirmed}). Continuing anyway.")
+        return False
+
+    def _send_wavelength(self, wavelength_nm: float) -> str:
+        self.device.write(f"VW= {int(wavelength_nm)}\r".encode("ascii"))
+        return self.device.readline().decode("ascii", errors="replace").strip()
+
+    # ------ Internal Safety ------
+    def _ensure_connected(self):
+        if not self._connected:
+            raise RuntimeError(f"{self.name} not connected. Call connect() first.")

--- a/SHG-experiment.py
+++ b/SHG-experiment.py
@@ -14,7 +14,8 @@ sys.path.append(r"C:\Users\schul\code\lab-automation")
 
 from LightFieldControls import LightField 
 from KinesisControls import (K10CR2, PRMTZ8) 
-from PowerMeterControls import PM100D 
+from PowerMeterControls import PM100D
+from LaserControls import ChameleonLaser
 
 from Thorlabs.MotionControl.DeviceManagerCLI import DeviceNotReadyException # for error handling 
 ###############################################################################
@@ -61,21 +62,27 @@ def setup():
     devices['mirror'].connect()  
         
     # Connect to the power meter
-    devices['PM'] = PM100D('USB0::4883::32888::P0007396::0::INSTR') 
-    
-    # Ask for pump wavelength 
-    set_pump_wavelength() 
+    devices['PM'] = PM100D('USB0::4883::32888::P0007396::0::INSTR')
+
+    # Connect to the tunable pump laser
+    devices['laser'] = ChameleonLaser('laser')
+    devices['laser'].connect()
+
+    # Ask for pump wavelength
+    set_pump_wavelength()
     
     return  
 
 def set_pump_wavelength():
-    while True: 
-        try: 
-            params["pump wavelength"] = input("What is the pump wavelength? (in nm) \n***Note: you still need to change the laser manually*** \n>")
-            break 
-        except ValueError(): 
+    while True:
+        try:
+            wavelength = float(input("What is the pump wavelength? (in nm) \n>"))
+            break
+        except ValueError:
             print("Only enter numbers please.")
-    print(f"Pump wavelength set to {params['pump wavelength']} nm (file name, not laser setting or refractive index)")
+    devices['laser'].set_wavelength(wavelength)
+    params["pump wavelength"] = wavelength
+    print(f"Pump wavelength set to {params['pump wavelength']} nm and laser driven to match.")
         
 def check_devices():
     # Calls a 'get' method on each device to check that they're connected 
@@ -84,8 +91,9 @@ def check_devices():
         devices['attenuator'].get_position() 
         devices['analyzer'].get_position() 
         devices['hwp'].get_position() 
-        devices['mirror'].get_position() 
+        devices['mirror'].get_position()
         devices['PM'].identify()
+        devices['laser'].get_wavelength()
         print("All devices are connected")
         return True 
     except Exception as e: 
@@ -115,8 +123,9 @@ def finish():
             devices['hwp'].disconnect()
             devices['analyzer'].disconnect() 
             devices['mirror'].disconnect() 
-            devices['PM'].disconnect() 
-            devices['lf'].close() 
+            devices['PM'].disconnect()
+            devices['laser'].disconnect()
+            devices['lf'].close()
             return 
         if answer == 'n':
             print("Aborting finish()")
@@ -703,10 +712,11 @@ params = {"pump wavelength" : 1080, # (nm)
 if not ('devices' in globals() or 'devices' in locals()):
     devices = {'lf' : None,
                'attenuator' : None,
-               'hwp' : None, 
-               'analyzer' : None, 
+               'hwp' : None,
+               'analyzer' : None,
                'mirror' : None,
-               'PM' : None
+               'PM' : None,
+               'laser' : None
                }
 
 degrees = []

--- a/laser_control_hardware_test_guide.md
+++ b/laser_control_hardware_test_guide.md
@@ -1,0 +1,119 @@
+# First real-hardware test: laser wavelength control
+
+New code: `LaserControls.py` (new file) + wavelength-control wiring in `SHG-experiment.py`
+(`ChameleonLaser` class, `set_pump_wavelength()`, `check_devices()`, `setup()`, `finish()`).
+None of this has been run against the real laser yet — only syntax-checked. Work through these
+steps in order on the lab PC before trusting it inside a real experiment.
+
+## 0. Prerequisites
+
+- [ ] `pyserial` is installed in whatever Python env runs `SHG-experiment.py` on the lab PC
+      (`pip install pyserial` if not — check with `python -c "import serial"`).
+- [ ] Confirm the laser is still on **COM6** in Device Manager (`LaserControls.py` hardcodes
+      `DEFAULT_PORT = "COM6"`, `DEFAULT_BAUD = 19200`, matching `sweep-ple.py`). If it's on a
+      different port, either pass `port=` when constructing `ChameleonLaser`, or update
+      `DEFAULT_PORT` at the top of `LaserControls.py`.
+- [ ] Nothing else has the COM6 port open (close any other terminal/script talking to the
+      laser first — the port can only be opened by one process at a time).
+
+## 1. Isolated connect test
+
+Before touching `SHG-experiment.py` at all, sanity-check the new class stand-alone from a
+Python shell in the lab-automation directory:
+
+```python
+from LaserControls import ChameleonLaser
+laser = ChameleonLaser('laser')
+laser.connect()
+```
+
+- [ ] No exception raised.
+- [ ] Console prints `laser connected on COM6.`. If instead you see
+      `laser: unexpected wavelength response: ...` from the priming read right after, the
+      buffer-flush timing (`reset_input_buffer`/`reset_output_buffer` + 0.5s sleep) isn't fully
+      clearing the laser's welcome/status bytes on this firmware — this was empirically tuned
+      in `sweep-ple.py`, so if it fails here, try increasing the `time.sleep(0.5)` in
+      `ChameleonLaser.connect()` to 1.0s or more.
+
+## 2. get_wavelength() sanity check
+
+```python
+wl = laser.get_wavelength()
+print(wl)
+```
+
+- [ ] Returns a real float close to whatever the laser's front panel / software shows, not
+      `None`.
+- [ ] If it returns `None`, check the printed `unexpected wavelength response` line — a raw
+      garbled string usually means stale bytes are still in the input buffer (see step 1) or
+      the port/baud is wrong.
+
+## 3. set_wavelength() end-to-end
+
+Pick a wavelength a few nm away from the current one so you can visually confirm motion:
+
+```python
+laser.set_wavelength(laser.get_wavelength() + 5)
+```
+
+- [ ] Laser physically moves (visible on its front panel/software or in the printed polling
+      output).
+- [ ] Console shows the polling loop counting up (`Waiting for laser... current: ... nm`) and
+      eventually `laser wavelength confirmed: ... nm` within 20 s.
+- [ ] Try a case where you expect it to almost immediately succeed (small jump) and a case with
+      a larger jump (e.g. 20+ nm) to see the polling loop handle a longer settle time.
+- [ ] If you see `no movement detected, resending wavelength command...` — this is the
+      known "first command sometimes dropped" retry path from `sweep-ple.py`; confirm the
+      resend actually gets the laser moving afterward.
+- [ ] If you see the final `WARNING: laser did not reach ... nm within 20.0s ... Continuing
+      anyway.` — that's a non-fatal timeout; check whether the laser was actually close to
+      target or genuinely stuck, and consider raising `max_wait_s` if large jumps routinely
+      need more time.
+
+`laser.disconnect()` when done with this isolated test.
+
+## 4. Inside SHG-experiment.py: setup()
+
+Run `setup()` from the normal menu (option 1) as usual.
+
+- [ ] All the existing devices (LightField, attenuator, hwp, analyzer, mirror, PM) still
+      connect exactly as before — laser wiring was inserted between the PM100D connection and
+      the `set_pump_wavelength()` call and shouldn't affect anything upstream.
+- [ ] The new `Connect to the tunable pump laser` step succeeds (same checks as steps 1-2
+      above, now happening inside `setup()`).
+- [ ] The subsequent `set_pump_wavelength()` prompt (`What is the pump wavelength? (in nm)`)
+      now actually drives the laser instead of just recording a number — confirm it moves to
+      the value you type in and that `params["pump wavelength"]` ends up as a float
+      afterward (it's used later in a numeric comparison in `set_power_and_pol()`, so a
+      leftover string there would silently misbehave — this was a pre-existing bug this
+      change also fixes).
+
+## 5. check_devices() (menu option 2)
+
+- [ ] Runs cleanly and prints `All devices are connected` with the laser wired in — should not
+      hang (the serial `readline()` has `timeout=2`, so a dead laser connection should fail
+      fast rather than blocking `check_devices()` forever).
+
+## 6. finish() (menu option 10)
+
+- [ ] Answering `y` disconnects everything including the laser (`laser disconnected.` printed)
+      without leaving the COM6 port locked (verify a fresh Python session can reopen it
+      afterward).
+
+## 7. Only then: a real experiment run
+
+Once steps 1-6 all pass, run a short `reflection_experiment()` or `SHG_experiment()` and
+confirm the pump wavelength set at the start of the run is the one actually reflected in your
+data/filenames (`params["pump wavelength"]` feeds directly into the acquisition filenames).
+
+## If something goes wrong
+
+- Garbled/`None` responses persistently → almost certainly a buffer-flush/timing issue specific
+  to this laser's firmware; the equivalent code in `sweep-ple.py` (which this was ported from)
+  has been used successfully on the same hardware, so compare timing constants there first.
+- Port errors (`could not open port COM6`) → another process (old Python shell, `sweep-ple.py`,
+  a terminal program) likely still has the port open.
+- `RuntimeError: laser not connected. Call connect() first.` from any method → `connect()`
+  failed silently earlier (check for a printed `Failed to connect to laser: ...` message) —
+  `check_devices()`/`set_pump_wavelength()` etc. all assume `connect()` succeeded during
+  `setup()`.


### PR DESCRIPTION
Ports the Coherent Chameleon serial-control logic from sweep-ple.py (get/set wavelength, buffer-priming, and confirm-with-retry polling) into a new ChameleonLaser class in LaserControls.py, matching the class-based device style already used by K10CR2/PRMTZ8/PM100D.

Wires it into SHG-experiment.py: setup() now connects the laser, check_devices()/finish() include it, and set_pump_wavelength() drives the laser to the requested wavelength instead of only recording a manually-typed number. Also fixes two latent bugs in set_pump_wavelength(): the except ValueError() invocation bug and params["pump wavelength"] never being cast to a number.

Includes laser_control_hardware_test_guide.md for the first real- hardware smoke test, since this machine has no lab hardware to test against.