### PR TITLE
Add LaserControls.py to README tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Python automation for an angle-resolved reflection / second-harmonic-generation 
 measurement rig: a LightField spectrometer/camera, several Thorlabs Kinesis rotation stages,
 and a Thorlabs power meter, driven together from a single interactive script.
 
-Each instrument is wrapped in its own class (`LightField`, `K10CR2`/`PRMTZ8`, `PM100D`), and
-`SHG-experiment.py` composes them into a menu-driven workflow for calibrating the rig and
-running reflection/SHG sweeps across E(k)-space.
+Each instrument is wrapped in its own class (`LightField`, `K10CR2`/`PRMTZ8`, `PM100D`,
+`ChameleonLaser`), and `SHG-experiment.py` composes them into a menu-driven workflow for
+calibrating the rig and running reflection/SHG sweeps across E(k)-space.
 
 ## Requirements
 
@@ -19,6 +19,7 @@ cross-platform drivers.
 | Thorlabs Kinesis (`Thorlabs.MotionControl.*` DLLs) | `KinesisControls.py` | Installed with the Kinesis desktop app |
 | Princeton Instruments LightField Automation SDK | `LightFieldControls.py` | Installed with LightField |
 | [`pyvisa`](https://pyvisa.readthedocs.io/) + NI-VISA (or Thorlabs' VISA driver) | `PowerMeterControls.py` | For the PM100D power meter |
+| [`pyserial`](https://pyserial.readthedocs.io/) | `LaserControls.py` | For the pump laser's serial (COM port) interface |
 | `numpy`, `pandas`, `scipy`, `matplotlib` | plotting scripts | Standard scientific stack |
 
 Device identifiers are hardcoded per-rig and will need updating if you're setting this up on a
@@ -26,6 +27,7 @@ different bench:
 - Rotation-stage serial numbers and the PM100D VISA resource string are set inside
   `setup()` in `SHG-experiment.py`.
 - The LightField SDK path is set at the top of `LightFieldControls.py`.
+- The pump laser's COM port/baud rate are set at the top of `LaserControls.py`.
 
 ## Quick start
 
@@ -62,6 +64,7 @@ method on any connected device — handy for one-off moves/reads without writing
 | `LightFieldControls.py` | `LightField` class — launches/controls Princeton Instruments LightField (exposure, center wavelength, grating, CSV acquisition) via pythonnet. |
 | `KinesisControls.py` | `K10CR2` / `PRMTZ8` classes — Thorlabs Kinesis rotation and motion stage control via pythonnet. |
 | `PowerMeterControls.py` | `PM100D` class — Thorlabs power meter readout via PyVISA. |
+| `LaserControls.py` | `ChameleonLaser` class — sets/reads the pump laser's wavelength over serial, with confirm-and-retry polling until the laser settles on target. |
 | `SpectrometerWavelengthRanges.py` | Per-center-wavelength pixel→wavelength lookup table, used by `LightFieldControls.py` to label CSV output columns. |
 
 ### Plotting / analysis


### PR DESCRIPTION
Documents the pump-laser control module (still on the unmerged worktree-laser-wavelength-control branch) alongside the other device control modules, plus its pyserial dependency and hardcoded COM port/baud rate note.